### PR TITLE
suppress invalid upos warning

### DIFF
--- a/lemminflect/__init__.py
+++ b/lemminflect/__init__.py
@@ -3,7 +3,7 @@ import logging
 from   .core.Inflections import Inflections
 from   .core.Lemmatizer  import Lemmatizer
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 
 
 # Lemmatizer is a singleton so this will only instantiate and load the data

--- a/lemminflect/core/Inflections.py
+++ b/lemminflect/core/Inflections.py
@@ -62,7 +62,7 @@ class Inflections(Singleton):
     # Return a dictionary of inflections, keyed by Penn Tag  and a tuple
     # of the possible spellings as the value
     def getAllInflectionsOOV(self, lemma, upos):
-        if upos not in self.DICT_UPOS_TYPES:
+        if upos is not None and upos not in self.DICT_UPOS_TYPES:
             self.logger.warning('Invalid upos type = %s', upos)
             return {}
         caps_style = getCapsStyle(lemma)


### PR DESCRIPTION
for the expected case of OOV with unknown tag, when called from https://github.com/bjascob/LemmInflect/blob/master/lemminflect/core/Inflections.py#L124